### PR TITLE
added new controlled road class RCT

### DIFF
--- a/src/main/java/ca/bc/gov/ols/enums/RoadClass.java
+++ b/src/main/java/ca/bc/gov/ols/enums/RoadClass.java
@@ -24,6 +24,7 @@ public enum RoadClass {
 	ARTERIAL_MINOR("arterial_minor", "RA2", true, 2),
 	COLLECTOR_MAJOR("collector_major", "RC1", true, 2),
 	COLLECTOR_MINOR("collector_minor", "RC2", true, 2),
+	CONTROLLED("controlled", "RCT", false, 1),
 	DRIVEWAY("driveway", "RPD", true, 1),
 	FERRY("ferry", "F", true, 0),
 	FERRY_PASSENGER("ferry_passenger", "FP", false, 0),


### PR DESCRIPTION
Note - there is another pull request coming, specifically for the OLS router changes. In order to make use of these changes, we will need a new OLS-Util version number, and it will need to get into the ols-router and ols-geoserver pom.xml files. Furthermore, the ols-geocoder project contains the streetprep code which is used to prepare the road data for both the geocoder and router - so if the geocoder doesn't get updated, (for data-integration purposes) then router will never see this change come through in the data. However, none of this is critical to the routing functionality, as unknown road classes are accepted and interpreted as unrouteable by default.